### PR TITLE
[Fixed] 보스 미사일이 추적하지 않는 오류 수정

### DIFF
--- a/Assets/MMJ/Scripts/BossMonsterMissile.cs
+++ b/Assets/MMJ/Scripts/BossMonsterMissile.cs
@@ -7,7 +7,11 @@ public class BossMonsterMissile : MonsterBullet
     public Transform target;
     public float moveSpeed;
 
-  
+    void Update()
+    {
+        Trace();
+    }
+
     private void Trace()
     {
         


### PR DESCRIPTION
유니티 업데이트 메세지 함수 안에 추적을 넣지 않았던 오류 수정